### PR TITLE
Dynamic secret refactor

### DIFF
--- a/core/schema/secret.go
+++ b/core/schema/secret.go
@@ -65,10 +65,14 @@ func (s *secretSchema) setSecret(ctx *router.Context, parent any, args setSecret
 }
 
 func (s *secretSchema) plaintext(ctx *router.Context, parent core.Secret, args any) (string, error) {
-	idStr := parent.ID.String()
+	digest, err := parent.ID.Digest()
+	// if it is the old format that doesn't use digests
+	if err != nil || digest == "" {
+		bytes, err := parent.Plaintext(ctx, s.gw)
+		return string(bytes), err
+	}
 
-	// FIXME: remove
-	// bytes, err = parent.Plaintext(ctx, s.gw)
+	idStr := parent.ID.String()
 	bytes, err := s.secrets.GetSecret(ctx, idStr)
 	if err != nil {
 		return "", err

--- a/core/schema/secret.go
+++ b/core/schema/secret.go
@@ -54,7 +54,10 @@ type setSecretArgs struct {
 }
 
 func (s *secretSchema) setSecret(ctx *router.Context, parent any, args setSecretArgs) (*core.Secret, error) {
-	secretID := s.secrets.AddSecret(ctx, args.Name, args.Plaintext)
+	secretID, err := s.secrets.AddSecret(ctx, args.Name, args.Plaintext)
+	if err != nil {
+		return nil, err
+	}
 
 	return &core.Secret{
 		ID: secretID,

--- a/core/secret.go
+++ b/core/secret.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"log"
 	"os"
 
 	bkgw "github.com/moby/buildkit/frontend/gateway/client"
@@ -66,8 +65,8 @@ type secretIDPayload struct {
 	FromFile    FileID `json:"file,omitempty"`
 	FromHostEnv string `json:"host_env,omitempty"`
 
-	Name   string
-	Digest string
+	Name   string `json:"name,omitempty"`
+	Digest string `json:"digest,omitempty"`
 }
 
 // Encode returns the opaque string ID representation of the secret.
@@ -94,7 +93,6 @@ func (secret *Secret) Plaintext(ctx context.Context, gw bkgw.Client) ([]byte, er
 	if err != nil {
 		return nil, err
 	}
-	log.Println("DBGTHE: SECRET: PLAINTEXT:", payload)
 	if payload.FromFile != "" {
 		file := &File{ID: payload.FromFile}
 		return file.Contents(ctx, gw)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -160,8 +160,8 @@ func Start(ctx context.Context, startOpts *Config, fn StartCallback) error {
 				Platform:       *platform,
 				DisableHostRW:  startOpts.DisableHostRW,
 				Auth:           registryAuth,
+				EnableServices: os.Getenv(engine.ServicesDNSEnvName) != "0",
 				Secrets:        secretStore,
-				EnableServices: os.Getenv(engine.ServicesDNSEnvName) != "",
 			})
 			if err != nil {
 				return nil, err

--- a/secret/store.go
+++ b/secret/store.go
@@ -32,11 +32,14 @@ func (store *Store) SetGateway(gw bkgw.Client) {
 
 // AddSecret adds the secret identified by user defined name with its plaintext
 // value to the secret store.
-func (store *Store) AddSecret(_ context.Context, name, plaintext string) core.SecretID {
+func (store *Store) AddSecret(_ context.Context, name, plaintext string) (core.SecretID, error) {
 	store.mu.Lock()
 	defer store.mu.Unlock()
 
-	id := core.NewSecretID(name, plaintext)
+	id, err := core.NewSecretID(name, plaintext)
+	if err != nil {
+		return id, err
+	}
 
 	digest, err := id.Digest()
 	if err != nil {
@@ -51,7 +54,7 @@ func (store *Store) AddSecret(_ context.Context, name, plaintext string) core.Se
 	// add the plaintext to the map
 	store.idToPlaintext[id] = plaintext
 
-	return id
+	return id, nil
 }
 
 // GetSecret returns the plaintext from the id.


### PR DESCRIPTION
In the [dynamic secret PR](https://github.com/dagger/dagger/pull/4667) I added a new way to encode secrets.
Later on I thought on how to use the same system for both without breaking the previous API.
Though, during that refactor, I broke the previous API (haha) on some side effects. It seems to break the file secret part, but I don't understand how/why.
I need some more eyes/help.
I hereby conjure @jlongtine , @vito , @sipsma and @aluzzardi.

The [TestSecretFromFileGoSDK](https://github.com/dolanor/dagger/blob/99722619eed19fa2c996fb9323b0bb3fcdf66232/core/integration/secret_test.go#L131-L165) will succeed with the special encoding, and will fail if I just use the secretIDPayload and add some fields (`name` and `digest` respectively) 